### PR TITLE
Correct the member name key specfiied on a validation failure. It was…

### DIFF
--- a/src/Exizent.ComponentModel.DataAnnotations/SumsToAttribute.cs
+++ b/src/Exizent.ComponentModel.DataAnnotations/SumsToAttribute.cs
@@ -28,22 +28,20 @@ public class SumsToAttribute : ValidationAttribute
             return ValidationResult.Success;
 
         decimal sum = 0m;
-        int index = 0;
         foreach (var item in evaluated)
         {
-            var propertyInfo = evaluated[index].GetType().GetProperty(ChildPropertyName);
+            var propertyInfo = item.GetType().GetProperty(ChildPropertyName);
             if (propertyInfo is null)
                 throw new InvalidOperationException($"The property '{ChildPropertyName}' is missing");
-            
+
             sum += Convert.ToDecimal(propertyInfo.GetValue(item));
-            if (sum > _expected || index == evaluated.Length - 1)
+            if (sum > _expected)
                 break;
-            index++;
         }
 
         return sum == (decimal)Expected ? ValidationResult.Success : new ValidationResult(
             $"The '{ChildPropertyName}' members of '{validationContext.MemberName}' must sum to {Expected}", 
-            new []{$"{validationContext.MemberName}[{index}].{ChildPropertyName}"}
+            new []{ChildPropertyName}
         );
     }
 }

--- a/tests/Exizent.ComponentModel.DataAnnotations.Tests/SumsToAttributeTests.cs
+++ b/tests/Exizent.ComponentModel.DataAnnotations.Tests/SumsToAttributeTests.cs
@@ -96,7 +96,7 @@ public class SumsToAttributeTests
         isValid.Should().BeFalse();
         results.Should().NotBeEmpty().And.HaveCount(1);
         results[0].ErrorMessage.Should().Be("The 'Percentage' members of 'Values' must sum to 1");
-        results[0].MemberNames.Single().Should().Be("Values[1].Percentage");
+        results[0].MemberNames.Single().Should().Be("Percentage");
     }
 
     public class WhenChildValueIsNullable
@@ -164,7 +164,7 @@ public class SumsToAttributeTests
             isValid.Should().BeFalse();
             results.Should().NotBeEmpty().And.HaveCount(1);
             results[0].ErrorMessage.Should().Be("The 'Percentage' members of 'Values' must sum to 1");
-            results[0].MemberNames.Single().Should().Be("Values[1].Percentage");
+            results[0].MemberNames.Single().Should().Be("Percentage");
         }
     }
     
@@ -243,7 +243,7 @@ public class SumsToAttributeTests
             isValid.Should().BeFalse();
             results.Should().NotBeEmpty().And.HaveCount(1);
             results[0].ErrorMessage.Should().Be("The 'Percentage' members of 'Values' must sum to 1");
-            results[0].MemberNames.Single().Should().Be("Values[1].Percentage");
+            results[0].MemberNames.Single().Should().Be("Percentage");
         }
     }
 }


### PR DESCRIPTION
… too specific and corrupting the message