### PR TITLE
Update .NET targets, add DateOnly attributes, and improve CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -10,17 +10,17 @@ jobs:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
     - name: Docker Build NuGet packages
       run: |
         docker build --build-arg NUGET_PACKAGE_VERSION=${{ env.VERSION }} -f ./src/Exizent.ComponentModel.DataAnnotations/Dockerfile --output ./ .
     - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1
+      uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
-        files: TestResults/**/*.xml
+        files: TestResults/**/*.trx
     - name: NuGet.Org push
       if: github.ref == 'refs/heads/main'
       run: |
@@ -28,12 +28,12 @@ jobs:
     - name: Create Release
       id: create_release
       if: github.ref == 'refs/heads/main'
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ env.VERSION }}
-        release_name: Release ${{ env.VERSION }}
+        name: Release ${{ env.VERSION }}
         body: |
           Release ${{ env.VERSION }}
         draft: false

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ bool isValid = Validator.TryValidateObject(model, context, results, validateAllP
 ### Collection, Comparison & Membership Attributes
 
 - [ContainsAny](#containsany)
+- [DateOnlyCompare](#dateonlycompare)
+- [DateOnlyCompareToday](#dateonlycomparetoday)
 - [DateTimeCompare](#datetimecompare)
 - [DateTimeCompareToday](#datetimecomparetoday)
 - [StringKeyLength](#stringkeylength)
@@ -598,6 +600,51 @@ public class Maths
 
 ---
 
+### DateOnlyCompare
+
+Compares a `DateOnly` property against another `DateOnly` property using an `EqualityCondition`.
+
+```csharp
+public class DateRange
+{
+    public DateOnly? StartDate { get; set; }
+
+    [DateOnlyCompare(nameof(StartDate), EqualityCondition.GreaterThan)]
+    public DateOnly? EndDate { get; set; }
+}
+```
+
+**Error message:** `"The field {0} must be {1} {2}."`
+
+| Parameter | Description |
+|-----------|-------------|
+| `{0}` | Current property name |
+| `{1}` | Equality condition text (e.g. "greater than") |
+| `{2}` | Other property name |
+
+---
+
+### DateOnlyCompareToday
+
+Compares a `DateOnly` property against today's date using an `EqualityCondition`.
+
+```csharp
+public class Booking
+{
+    [DateOnlyCompareToday(EqualityCondition.GreaterThanOrEquals)]
+    public DateOnly? CheckInDate { get; set; }
+}
+```
+
+**Error message:** `"The field {0} must be {1} today."`
+
+| Parameter | Description |
+|-----------|-------------|
+| `{0}` | Current property name |
+| `{1}` | Equality condition text (e.g. "greater than or equal to") |
+
+---
+
 ### DateTimeCompare
 
 Compares a `DateTime` property against another `DateTime` property using an `EqualityCondition`.
@@ -722,7 +769,7 @@ public class Portfolio
 
 ## EqualityCondition Enum
 
-Used by [`DateTimeCompare`](#datetimecompare) and [`DateTimeCompareToday`](#datetimecomparetoday) to specify the comparison operation.
+Used by [`DateOnlyCompare`](#dateonlycompare), [`DateOnlyCompareToday`](#dateonlycomparetoday), [`DateTimeCompare`](#datetimecompare) and [`DateTimeCompareToday`](#datetimecomparetoday) to specify the comparison operation.
 
 | Value | Formatted Text |
 |-------|---------------|

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
-    "rollForward": "latestFeature"
+    "version": "8.0.100",
+    "rollForward": "latestMajor"
   }
 }

--- a/src/Exizent.ComponentModel.DataAnnotations/AvailableIfAttribute.cs
+++ b/src/Exizent.ComponentModel.DataAnnotations/AvailableIfAttribute.cs
@@ -27,5 +27,5 @@ public class AvailableIfAttribute : DependantPropertyBaseAttribute
     }
 
     private string FormatDependantPropertyRequiredValue()
-        => DependantPropertyRequiredValue is null ? "null" : DependantPropertyRequiredValue.ToString();
+        => DependantPropertyRequiredValue is null ? "null" : DependantPropertyRequiredValue.ToString()!;
 }

--- a/src/Exizent.ComponentModel.DataAnnotations/ContainsAnyAttribute.cs
+++ b/src/Exizent.ComponentModel.DataAnnotations/ContainsAnyAttribute.cs
@@ -22,7 +22,7 @@ public class ContainsAnyAttribute : ValidationAttribute
         if (value == null)
             return true;
 
-        var instance = Activator.CreateInstance(_valueProviderType);
+        var instance = Activator.CreateInstance(_valueProviderType)!;
 
         if(ContainsMethodHelper.TryGetContainsMethod(instance, out var containsMethod))
         {
@@ -45,7 +45,7 @@ public class ContainsAnyAttribute : ValidationAttribute
             var methodInfo = value.GetType().GetMethod("Contains");
             if (methodInfo != null && methodInfo.GetParameters().Length == 1 && methodInfo.ReturnType == typeof(bool))
             {
-                contains = input => (bool)methodInfo.Invoke(value, new[] { input });
+                contains = input => (bool)methodInfo.Invoke(value, new[] { input })!;
                 return true;
             }
             

--- a/src/Exizent.ComponentModel.DataAnnotations/DateOnlyCompareAttribute.cs
+++ b/src/Exizent.ComponentModel.DataAnnotations/DateOnlyCompareAttribute.cs
@@ -1,0 +1,29 @@
+namespace Exizent.ComponentModel.DataAnnotations;
+
+public class DateOnlyCompareAttribute : DateOnlyCompareBaseAttribute
+{
+    public DateOnlyCompareAttribute(string otherProperty, EqualityCondition equalityCondition)
+        : base(equalityCondition)
+    {
+        OtherProperty = otherProperty;
+    }
+
+    public string OtherProperty { get; }
+
+    protected override DateOnly? GetOtherDateOnlyValue(ValidationContext validationContext)
+    {
+        if (validationContext.ObjectType.GetProperty(OtherProperty) is not { } otherPropertyInfo)
+        {
+            throw new InvalidOperationException($"The other property '{OtherProperty}' does not exist");
+        }
+
+        return (DateOnly?)otherPropertyInfo.GetValue(validationContext.ObjectInstance, null);
+    }
+
+    protected override string FormatErrorMessage(ValidationContext validationContext, DateOnly? date)
+        => string.Format(ErrorMessageString,
+            validationContext.DisplayName,
+            DateTimeCompareBaseAttribute.FormatEqualityCondition(EqualityCondition),
+            OtherProperty);
+}
+

--- a/src/Exizent.ComponentModel.DataAnnotations/DateOnlyCompareBaseAttribute.cs
+++ b/src/Exizent.ComponentModel.DataAnnotations/DateOnlyCompareBaseAttribute.cs
@@ -1,0 +1,62 @@
+namespace Exizent.ComponentModel.DataAnnotations;
+
+public abstract class DateOnlyCompareBaseAttribute : ValidationAttribute
+{
+    protected DateOnlyCompareBaseAttribute(EqualityCondition equalityCondition,
+        string errorMessage = "The field {0} must be {1} {2}.")
+        : base(errorMessage)
+    {
+        EqualityCondition = equalityCondition;
+    }
+
+    public EqualityCondition EqualityCondition { get; }
+
+    protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
+    {
+        var result = ValidationResult.Success!;
+
+        var current = (DateOnly?)value;
+
+        var other = GetOtherDateOnlyValue(validationContext);
+
+        if (!Enum.IsDefined(typeof(EqualityCondition), EqualityCondition))
+            throw new InvalidOperationException($"Invalid equality condition {EqualityCondition}");
+
+        if (!Compare(current, other))
+        {
+            var memberNames = validationContext.MemberName != null
+                ? new[] { validationContext.MemberName }
+                : null;
+
+            result = new ValidationResult(
+                FormatErrorMessage(validationContext, other),
+                memberNames);
+        }
+
+        return result;
+    }
+
+    protected virtual string FormatErrorMessage(ValidationContext validationContext, DateOnly? date)
+        => string.Format(ErrorMessageString, validationContext.DisplayName,
+            DateTimeCompareBaseAttribute.FormatEqualityCondition(EqualityCondition), date);
+
+    protected abstract DateOnly? GetOtherDateOnlyValue(ValidationContext validationContext);
+
+    private bool Compare(DateOnly? current, DateOnly? other)
+    {
+        if (current is null || other is null)
+            return true;
+
+        return EqualityCondition switch
+        {
+            EqualityCondition.Equals => current == other,
+            EqualityCondition.NotEquals => current != other,
+            EqualityCondition.GreaterThan => current > other,
+            EqualityCondition.GreaterThanOrEquals => current >= other,
+            EqualityCondition.LessThan => current < other,
+            EqualityCondition.LessThanOrEquals => current <= other,
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+}
+

--- a/src/Exizent.ComponentModel.DataAnnotations/DateOnlyCompareTodayAttribute.cs
+++ b/src/Exizent.ComponentModel.DataAnnotations/DateOnlyCompareTodayAttribute.cs
@@ -1,0 +1,13 @@
+namespace Exizent.ComponentModel.DataAnnotations;
+
+public class DateOnlyCompareTodayAttribute : DateOnlyCompareBaseAttribute
+{
+    public DateOnlyCompareTodayAttribute(EqualityCondition equalityCondition)
+        : base(equalityCondition, "The field {0} must be {1} today.")
+    {
+    }
+
+    protected override DateOnly? GetOtherDateOnlyValue(ValidationContext validationContext)
+        => DateOnly.FromDateTime(DateTime.Today);
+}
+

--- a/src/Exizent.ComponentModel.DataAnnotations/Dockerfile
+++ b/src/Exizent.ComponentModel.DataAnnotations/Dockerfile
@@ -1,7 +1,7 @@
 ﻿ARG CONFIGURATION="Release"
 ARG NUGET_PACKAGE_VERSION="1.0.0"
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS restore
 
 ARG CONFIGURATION
 ENV PATH="/root/.dotnet/tools:${PATH}"
@@ -10,6 +10,7 @@ COPY ./*.props .
 COPY ./*.targets .
 COPY ./*.sln .
 COPY ./*.png .
+COPY ./global.json .
 
 COPY ./src/Exizent.ComponentModel.DataAnnotations/*.csproj ./src/Exizent.ComponentModel.DataAnnotations/
 COPY ./tests/Exizent.ComponentModel.DataAnnotations.Tests/*.csproj ./tests/Exizent.ComponentModel.DataAnnotations.Tests/
@@ -24,7 +25,7 @@ COPY ./tests/ ./tests/
 RUN dotnet build --configuration $CONFIGURATION --no-restore
 
 FROM build as test
-RUN dotnet test --logger "junit;LogFilePath=/TestResults/TestResults.xml" --configuration $CONFIGURATION --no-build
+RUN dotnet test --logger "trx;LogFilePath=/TestResults/TestResults.trx" --configuration $CONFIGURATION --no-build
 
 FROM build as pack
 RUN mkdir -p artifacts
@@ -33,5 +34,4 @@ RUN dotnet pack --configuration Release -p:Version=${NUGET_PACKAGE_VERSION} --no
 FROM scratch
 COPY --from=pack /artifacts/*.nupkg /artifacts/
 COPY --from=pack /artifacts/*.snupkg /artifacts/
-COPY --from=test /TestResults/*.xml /TestResults/
-
+COPY --from=test /TestResults/*.trx /TestResults/

--- a/src/Exizent.ComponentModel.DataAnnotations/Dockerfile
+++ b/src/Exizent.ComponentModel.DataAnnotations/Dockerfile
@@ -16,7 +16,7 @@ COPY ./src/Exizent.ComponentModel.DataAnnotations/*.csproj ./src/Exizent.Compone
 COPY ./tests/Exizent.ComponentModel.DataAnnotations.Tests/*.csproj ./tests/Exizent.ComponentModel.DataAnnotations.Tests/
 RUN dotnet restore
 
-FROM restore as build
+FROM restore AS build
 ARG CONFIGURATION
 ARG NUGET_PACKAGE_VERSION
 
@@ -24,10 +24,11 @@ COPY ./src/ ./src/
 COPY ./tests/ ./tests/
 RUN dotnet build --configuration $CONFIGURATION --no-restore
 
-FROM build as test
+FROM build AS test
+RUN mkdir -p /TestResults
 RUN dotnet test --logger "trx;LogFilePath=/TestResults/TestResults.trx" --configuration $CONFIGURATION --no-build
 
-FROM build as pack
+FROM build AS pack
 RUN mkdir -p artifacts
 RUN dotnet pack --configuration Release -p:Version=${NUGET_PACKAGE_VERSION} --no-build --output ./artifacts
 

--- a/src/Exizent.ComponentModel.DataAnnotations/Exizent.ComponentModel.DataAnnotations.csproj
+++ b/src/Exizent.ComponentModel.DataAnnotations/Exizent.ComponentModel.DataAnnotations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <NoWarn>1591</NoWarn>
     </PropertyGroup>
 
@@ -39,8 +39,6 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
     </PropertyGroup>
     
-    <ItemGroup>
-      <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    </ItemGroup>
+
 
 </Project>

--- a/tests/Exizent.ComponentModel.DataAnnotations.Tests/DateOnlyCompareAttributeTests.cs
+++ b/tests/Exizent.ComponentModel.DataAnnotations.Tests/DateOnlyCompareAttributeTests.cs
@@ -1,0 +1,341 @@
+namespace Exizent.ComponentModel.DataAnnotations.Tests;
+
+public class DateOnlyCompareAttributeTests
+{
+    class TestModel
+    {
+        public DateOnly? Value { get; set; }
+
+        [DateOnlyCompareAttribute(nameof(Value), EqualityCondition.Equals)]
+        public DateOnly? EqualsValue { get; set; }
+
+        [DateOnlyCompareAttribute(nameof(Value), EqualityCondition.NotEquals)]
+        public DateOnly? NotEqualsValue { get; set; }
+
+        [DateOnlyCompareAttribute(nameof(Value), EqualityCondition.GreaterThan)]
+        public DateOnly? GreaterThanValue { get; set; }
+
+        [DateOnlyCompareAttribute(nameof(Value), EqualityCondition.GreaterThanOrEquals)]
+        public DateOnly? GreaterThanOrEqualsValue { get; set; }
+
+        [DateOnlyCompareAttribute(nameof(Value), EqualityCondition.LessThan)]
+        public DateOnly? LessThanValue { get; set; }
+
+        [DateOnlyCompareAttribute(nameof(Value), EqualityCondition.LessThanOrEquals)]
+        public DateOnly? LessThanOrEqualsValue { get; set; }
+    }
+
+    class InvalidOtherPropertyTestClass
+    {
+        [DateOnlyCompareAttribute("PropertyThatDoesNotExist", EqualityCondition.Equals)]
+        public DateOnly? Value { get; set; }
+    }
+
+    class InvalidEqualityConditionTestClass
+    {
+        public DateOnly? OtherValue { get; set; }
+        [DateOnlyCompareAttribute(nameof(OtherValue), (EqualityCondition)int.MaxValue)]
+        public DateOnly? Value { get; set; }
+    }
+
+    private static (List<ValidationResult> results, bool isValid) ValidateModel<TModel>(TModel model) where TModel : notnull
+    {
+        var context = new ValidationContext(model);
+        var results = new List<ValidationResult>();
+
+        var isValid = Validator.TryValidateObject(model, context, results, true);
+        return (results, isValid);
+    }
+
+    [Fact]
+    public void ShouldBeValidForNullOtherPropertyValue()
+    {
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var model = new TestModel
+        {
+            Value = null,
+            EqualsValue = today,
+            NotEqualsValue = today,
+            GreaterThanValue = today,
+            GreaterThanOrEqualsValue = today,
+            LessThanValue = today,
+            LessThanOrEqualsValue = today,
+        };
+
+        var (results, isValid) = ValidateModel(model);
+
+        using var _ = new AssertionScope();
+        isValid.Should().BeTrue();
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ShouldBeValidForNullPropertyValue()
+    {
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var model = new TestModel
+        {
+            Value = today
+        };
+
+        var (results, isValid) = ValidateModel(model);
+
+        using var _ = new AssertionScope();
+        isValid.Should().BeTrue();
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ShouldThrowInvalidOperationExceptionForInvalidOtherProperty()
+    {
+        var model = new InvalidOtherPropertyTestClass
+        {
+            Value = DateOnly.FromDateTime(DateTime.Today)
+        };
+
+        Action action = () => ValidateModel(model);
+
+        action.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("The other property '*' does not exist");
+    }
+
+    [Fact]
+    public void ShouldThrowArgumentExceptionForInvalidEqualityCondition()
+    {
+        var model = new InvalidEqualityConditionTestClass
+        {
+            OtherValue = DateOnly.FromDateTime(DateTime.Today),
+            Value = DateOnly.FromDateTime(DateTime.Today)
+        };
+
+        Action action = () => ValidateModel(model);
+
+        action.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Invalid equality condition *");
+    }
+
+    [Theory]
+    [InlineData(EqualityCondition.Equals)]
+    [InlineData(EqualityCondition.NotEquals)]
+    [InlineData(EqualityCondition.GreaterThan)]
+    [InlineData(EqualityCondition.GreaterThanOrEquals)]
+    [InlineData(EqualityCondition.LessThan)]
+    [InlineData(EqualityCondition.LessThanOrEquals)]
+    public void ShouldExposeEqualityCondition(EqualityCondition condition)
+    {
+        var attribute = new DateOnlyCompareAttribute("Test", condition);
+
+        attribute.EqualityCondition.Should().Be(condition);
+    }
+
+    [Fact]
+    public void ShouldExposeOtherPropertyName()
+    {
+        var attribute = new DateOnlyCompareAttribute("Test", EqualityCondition.Equals);
+
+        attribute.OtherProperty.Should().Be("Test");
+    }
+
+    public class EqualsEqualityConditionTests
+    {
+        [Fact]
+        public void ShouldBeValidForDatesThatAreEqual()
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { Value = today, EqualsValue = today };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ShouldBeInvalidForDatesThatAreNotEqual()
+        {
+            var model = new TestModel { Value = DateOnly.MinValue, EqualsValue = DateOnly.MaxValue };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.EqualsValue)} must be equal to {nameof(TestModel.Value)}.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.EqualsValue));
+        }
+    }
+
+    public class NotEqualsEqualityConditionTests
+    {
+        [Fact]
+        public void ShouldBeValidForDatesThatAreNotEqual()
+        {
+            var model = new TestModel { Value = DateOnly.MinValue, NotEqualsValue = DateOnly.MaxValue };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ShouldBeInvalidForDatesThatAreEqual()
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { Value = today, NotEqualsValue = today };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.NotEqualsValue)} must be not equal to {nameof(TestModel.Value)}.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.NotEqualsValue));
+        }
+    }
+
+    public class GreaterThanEqualityConditionTests
+    {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void ShouldBeValidForDatesThatAreGreaterThan(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { Value = today, GreaterThanValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void ShouldBeInvalidForDatesThatAreNotGreaterThan(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { Value = today, GreaterThanValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.GreaterThanValue)} must be greater than {nameof(TestModel.Value)}.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.GreaterThanValue));
+        }
+    }
+
+    public class GreaterThanOrEqualsEqualityConditionTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ShouldBeValidForDatesThatAreGreaterThanOrEquals(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { Value = today, GreaterThanOrEqualsValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(-2)]
+        public void ShouldBeInvalidForDatesThatAreNotGreaterThanOrEquals(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { Value = today, GreaterThanOrEqualsValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.GreaterThanOrEqualsValue)} must be greater than or equal to {nameof(TestModel.Value)}.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.GreaterThanOrEqualsValue));
+        }
+    }
+
+    public class LessThanEqualityConditionTests
+    {
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(-2)]
+        public void ShouldBeValidForDatesThatAreLessThan(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { Value = today, LessThanValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ShouldBeInvalidForDatesThatAreNotLessThan(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { Value = today, LessThanValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.LessThanValue)} must be less than {nameof(TestModel.Value)}.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.LessThanValue));
+        }
+    }
+
+    public class LessThanOrEqualsEqualityConditionTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void ShouldBeValidForDatesThatAreLessThanOrEquals(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { Value = today, LessThanOrEqualsValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void ShouldBeInvalidForDatesThatAreNotLessThanOrEquals(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { Value = today, LessThanOrEqualsValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.LessThanOrEqualsValue)} must be less than or equal to {nameof(TestModel.Value)}.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.LessThanOrEqualsValue));
+        }
+    }
+}
+

--- a/tests/Exizent.ComponentModel.DataAnnotations.Tests/DateOnlyCompareTodayAttributeTests.cs
+++ b/tests/Exizent.ComponentModel.DataAnnotations.Tests/DateOnlyCompareTodayAttributeTests.cs
@@ -1,0 +1,282 @@
+namespace Exizent.ComponentModel.DataAnnotations.Tests;
+
+public class DateOnlyCompareTodayAttributeTests
+{
+    class TestModel
+    {
+        [DateOnlyCompareToday(EqualityCondition.Equals)]
+        public DateOnly? EqualsValue { get; set; }
+
+        [DateOnlyCompareToday(EqualityCondition.NotEquals)]
+        public DateOnly? NotEqualsValue { get; set; }
+
+        [DateOnlyCompareToday(EqualityCondition.GreaterThan)]
+        public DateOnly? GreaterThanValue { get; set; }
+
+        [DateOnlyCompareToday(EqualityCondition.GreaterThanOrEquals)]
+        public DateOnly? GreaterThanOrEqualsValue { get; set; }
+
+        [DateOnlyCompareToday(EqualityCondition.LessThan)]
+        public DateOnly? LessThanValue { get; set; }
+
+        [DateOnlyCompareToday(EqualityCondition.LessThanOrEquals)]
+        public DateOnly? LessThanOrEqualsValue { get; set; }
+    }
+
+    class InvalidEqualityConditionTestClass
+    {
+        [DateOnlyCompareToday((EqualityCondition)int.MaxValue)]
+        public DateOnly? Value { get; set; }
+    }
+
+    private static (List<ValidationResult> results, bool isValid) ValidateModel<TModel>(TModel model) where TModel : notnull
+    {
+        var context = new ValidationContext(model);
+        var results = new List<ValidationResult>();
+
+        var isValid = Validator.TryValidateObject(model, context, results, true);
+        return (results, isValid);
+    }
+
+    [Fact]
+    public void ShouldBeValidForNullPropertyValue()
+    {
+        var model = new TestModel();
+
+        var (results, isValid) = ValidateModel(model);
+
+        using var _ = new AssertionScope();
+        isValid.Should().BeTrue();
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ShouldThrowArgumentExceptionForInvalidEqualityCondition()
+    {
+        var model = new InvalidEqualityConditionTestClass
+        {
+            Value = DateOnly.FromDateTime(DateTime.Today)
+        };
+
+        Action action = () => ValidateModel(model);
+
+        action.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Invalid equality condition *");
+    }
+
+    [Theory]
+    [InlineData(EqualityCondition.Equals)]
+    [InlineData(EqualityCondition.NotEquals)]
+    [InlineData(EqualityCondition.GreaterThan)]
+    [InlineData(EqualityCondition.GreaterThanOrEquals)]
+    [InlineData(EqualityCondition.LessThan)]
+    [InlineData(EqualityCondition.LessThanOrEquals)]
+    public void ShouldExposeEqualityCondition(EqualityCondition condition)
+    {
+        var attribute = new DateOnlyCompareTodayAttribute(condition);
+
+        attribute.EqualityCondition.Should().Be(condition);
+    }
+
+    public class EqualsEqualityConditionTests
+    {
+        [Fact]
+        public void ShouldBeValidForDatesThatAreEqual()
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { EqualsValue = today };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ShouldBeInvalidForDatesThatAreNotEqual()
+        {
+            var model = new TestModel { EqualsValue = DateOnly.MaxValue };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.EqualsValue)} must be equal to today.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.EqualsValue));
+        }
+    }
+
+    public class NotEqualsEqualityConditionTests
+    {
+        [Fact]
+        public void ShouldBeValidForDatesThatAreNotEqual()
+        {
+            var model = new TestModel { NotEqualsValue = DateOnly.MaxValue };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ShouldBeInvalidForDatesThatAreEqual()
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { NotEqualsValue = today };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.NotEqualsValue)} must be not equal to today.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.NotEqualsValue));
+        }
+    }
+
+    public class GreaterThanEqualityConditionTests
+    {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void ShouldBeValidForDatesThatAreGreaterThan(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { GreaterThanValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void ShouldBeInvalidForDatesThatAreNotGreaterThan(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { GreaterThanValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.GreaterThanValue)} must be greater than today.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.GreaterThanValue));
+        }
+    }
+
+    public class GreaterThanOrEqualsEqualityConditionTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ShouldBeValidForDatesThatAreGreaterThanOrEquals(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { GreaterThanOrEqualsValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(-2)]
+        public void ShouldBeInvalidForDatesThatAreNotGreaterThanOrEquals(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { GreaterThanOrEqualsValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.GreaterThanOrEqualsValue)} must be greater than or equal to today.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.GreaterThanOrEqualsValue));
+        }
+    }
+
+    public class LessThanEqualityConditionTests
+    {
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(-2)]
+        public void ShouldBeValidForDatesThatAreLessThan(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { LessThanValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ShouldBeInvalidForDatesThatAreNotLessThan(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { LessThanValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.LessThanValue)} must be less than today.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.LessThanValue));
+        }
+    }
+
+    public class LessThanOrEqualsEqualityConditionTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void ShouldBeValidForDatesThatAreLessThanOrEquals(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { LessThanOrEqualsValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeTrue();
+            results.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void ShouldBeInvalidForDatesThatAreNotLessThanOrEquals(int daysToAdd)
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var model = new TestModel { LessThanOrEqualsValue = today.AddDays(daysToAdd) };
+
+            var (results, isValid) = ValidateModel(model);
+
+            using var _ = new AssertionScope();
+            isValid.Should().BeFalse();
+            results[0].ErrorMessage.Should()
+                .Be($"The field {nameof(TestModel.LessThanOrEqualsValue)} must be less than or equal to today.");
+            results[0].MemberNames.Should().BeEquivalentTo(nameof(TestModel.LessThanOrEqualsValue));
+        }
+    }
+}
+

--- a/tests/Exizent.ComponentModel.DataAnnotations.Tests/Exizent.ComponentModel.DataAnnotations.Tests.csproj
+++ b/tests/Exizent.ComponentModel.DataAnnotations.Tests/Exizent.ComponentModel.DataAnnotations.Tests.csproj
@@ -1,21 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.2.0" />
-        <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="FluentAssertions" Version="8.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.2">
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
This pull request introduces support for .NET 8 and .NET 10, adds new validation attributes for `DateOnly` types, and updates the CI pipeline and Docker configuration to align with these changes. The documentation has also been updated to reflect the new attributes and usage. The most important changes are summarized below:

**.NET Version and Project Configuration Updates:**

* Updated the project to target both `net8.0` and `net10.0` frameworks in `Exizent.ComponentModel.DataAnnotations.csproj`, and removed the dependency on `System.ComponentModel.Annotations` since it's included in later frameworks. [[1]](diffhunk://#diff-817d2b957e4551932c738976f1c1a96086ea26e330aef5dac963f8f9fb99eac4L4-R4) [[2]](diffhunk://#diff-817d2b957e4551932c738976f1c1a96086ea26e330aef5dac963f8f9fb99eac4L42-R42)
* Updated `global.json` to use .NET SDK version 8.0.100 and set roll-forward to `latestMajor`.
* Updated the Dockerfile to use the .NET 10 SDK image, copy `global.json`, and build/test/package using the new frameworks. Test results are now output as `.trx` files instead of `.xml`. [[1]](diffhunk://#diff-4ad704940a707dfdbe9dc546ad0bf336e572e7713722569f2be397c4df72794fL4-R4) [[2]](diffhunk://#diff-4ad704940a707dfdbe9dc546ad0bf336e572e7713722569f2be397c4df72794fR13) [[3]](diffhunk://#diff-4ad704940a707dfdbe9dc546ad0bf336e572e7713722569f2be397c4df72794fL27-R28) [[4]](diffhunk://#diff-4ad704940a707dfdbe9dc546ad0bf336e572e7713722569f2be397c4df72794fL36-R37)

**New Validation Attributes for DateOnly:**

* Added `DateOnlyCompareAttribute`, `DateOnlyCompareTodayAttribute`, and a shared base class `DateOnlyCompareBaseAttribute` to enable validation of `DateOnly` properties against other properties or today's date using various equality conditions. [[1]](diffhunk://#diff-dd04749b034649e06cba9a22fe95404333255546f056df3b2c1dcb715c233a61R1-R29) [[2]](diffhunk://#diff-44d6ece710291c0f0ed44e3180efef19311ccff334a6f237663a449420fdb7ceR1-R13) [[3]](diffhunk://#diff-5f98e86486705d2627b1d882422c29a139ebde27a3d2eadc801d29a9eec1ec73R1-R62)

**Documentation Updates:**

* Updated `README.md` to document the new `DateOnlyCompare` and `DateOnlyCompareToday` attributes, including usage examples and error messages. Also updated the `EqualityCondition` enum documentation to reference the new attributes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R68) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R603-R647) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L725-R772)

**Continuous Integration Pipeline Updates:**

* Updated GitHub Actions workflow to use newer versions of actions (`checkout@v4`, `setup-dotnet@v4`, `publish-unit-test-result-action@v2`, `softprops/action-gh-release@v2`), switched test result file format to `.trx`, and updated release step.

**Code Quality Improvements:**

* Added null-forgiving operator (`!`) in several places to address nullable reference types and improve code reliability. [[1]](diffhunk://#diff-3795bba669e668258adfdff2721c315b46a6da45c4cedf0a5cc4585fa8378c3eL25-R25) [[2]](diffhunk://#diff-3795bba669e668258adfdff2721c315b46a6da45c4cedf0a5cc4585fa8378c3eL48-R48) [[3]](diffhunk://#diff-27e1995b30c6a75279991658f99f1cae28858ffaaf56d0c38902a33bdbd18eefL30-R30)